### PR TITLE
Rework to new C++ based add-on interface system

### DIFF
--- a/audiodecoder.dumb/addon.xml.in
+++ b/audiodecoder.dumb/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audiodecoder.dumb"
-  version="1.1.0"
+  version="2.0.0"
   name="Modplug Audio Decoder"
   provider-name="spiff">
   <requires>


### PR DESCRIPTION
Hi @notspiff ,

This request is currently not for merge. Only to check the way is basically OK.

There is good to see how I want to change it against the old style.

With them is the third add-on type where I checked with new style and also there it also runs direct without any problems :D

Here the new header: https://github.com/AlwinEsch/kodi/blob/add-addon-instance-handling/xbmc/addons/kodi-addon-dev-kit/include/kodi/audiodecoder/AudioDecoder.h
Here the docs to them: http://alwinesch.github.io/group__cpp__kodi__addon__audiodecoder.html

Is this way OK for you? Or some other ideas? Or complete the wrong way?
