### PR TITLE
[cmake] remove usage of kodi-platform

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,8 +1,7 @@
 Source: kodi-audiodecoder-dumb
 Priority: extra
 Maintainer: Arne Morten Kvarving <cptspiff@gmail.com>
-Build-Depends: debhelper (>= 8.0.0), cmake, kodi-addon-dev,
-               libkodiplatform-dev (>= 17.1.0)
+Build-Depends: debhelper (>= 8.0.0), cmake, kodi-addon-dev
 Standards-Version: 3.9.6
 Section: libs
 


### PR DESCRIPTION
The audiodecoder.dumb binary addon does not use kodi-platform.
Remove existing references from debian/control.