### PR TITLE
[Matrix|N*] mark addon as deprecated, copyright year increase and cleanup 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 This is a [Kodi](https://kodi.tv) audio decoder addon for IT, XM and S3M files.
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build Status](https://travis-ci.org/xbmc/audiodecoder.dumb.svg?branch=Matrix)](https://travis-ci.org/xbmc/audiodecoder.dumb/branches)
 [![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audiodecoder.dumb?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=1&branchName=Matrix)
 [![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/audiodecoder.dumb/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Faudiodecoder.dumb/branches/)
 <!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/audiodecoder.dumb?branch=Matrix&svg=true)](https://ci.appveyor.com/project/xbmc/audiodecoder-dumb?branch=Matrix) -->

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a [Kodi](https://kodi.tv) audio decoder addon for IT, XM and S3M files.
 
+> **NOTE:** It is recommended to use ["OpenMPT Audio Decoder"](https://github.com/xbmc/audiodecoder.openmpt) addon instead of this one. However, but still usable here.
+
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
 [![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audiodecoder.dumb?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=1&branchName=Matrix)
 [![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/audiodecoder.dumb/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Faudiodecoder.dumb/branches/)

--- a/audiodecoder.dumb/addon.xml.in
+++ b/audiodecoder.dumb/addon.xml.in
@@ -27,6 +27,8 @@ On Kodi Supports playback of the following module formats:
 - S3M (Scream Tracker 3)</description>
     <disclaimer lang="de_DE">Es wird empfohlen, anstelle dieses Addons "OpenMPT Audio Decoder" zu verwenden.</disclaimer>
     <disclaimer lang="en_GB">It is recommended to use "OpenMPT Audio Decoder" addon instead of this one.</disclaimer>
+    <lifecyclestate type="deprecated" lang="de_DE">Ersetzt durch das Addon audiodecoder.openmpt! Aber hier auch noch verwendbar.</lifecyclestate>
+    <lifecyclestate type="deprecated" lang="en_GB">Replaced by audiodecoder.openmpt addon! However, but still usable here.</lifecyclestate>
     <platform>@PLATFORM@</platform>
     <license>GPL-2.0-or-later</license>
     <source>https://github.com/xbmc/audiodecoder.dumb</source>

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,7 +3,7 @@ Upstream-Name: audiodecoder.dumb
 Source: https://github.com/xbmc/audiodecoder.2sf
 
 Files: *
-Copyright: 2005-2020 Team Kodi
+Copyright: 2005-2021 Team Kodi
 License: GPL-2+
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/lib/kodi-dumb-note.txt
+++ b/lib/kodi-dumb-note.txt
@@ -1,4 +1,6 @@
 dumb source from https://github.com/kode54/dumb
 Sync to 2.0.3 (30 Jan. 2018)
 
-Another source https://g.losno.co/chris/dumb
+Another source:
+- https://git.lopez-snowhill.net/chris/dumb
+- https://bitbucket.org/kode54/dumb

--- a/src/DumbCodec.cpp
+++ b/src/DumbCodec.cpp
@@ -1,6 +1,6 @@
 /*
- *  Copyright (C) 2014-2020 Arne Morten Kvarving
- *  Copyright (C) 2016-2020 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2014-2021 Arne Morten Kvarving
+ *  Copyright (C) 2016-2021 Team Kodi (https://kodi.tv)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/DumbCodec.h
+++ b/src/DumbCodec.h
@@ -1,6 +1,6 @@
 /*
- *  Copyright (C) 2014-2020 Arne Morten Kvarving
- *  Copyright (C) 2016-2020 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2014-2021 Arne Morten Kvarving
+ *  Copyright (C) 2016-2021 Team Kodi (https://kodi.tv)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.


### PR DESCRIPTION
- set copyright year to 2021
- remove the status badge about Travis CI
  - The build script stais currently in, maybe usable for something else or they allow again a bit more by travis.com
- Small cleanup of URL's by lib/kodi-dumb-note.txt
- Mark addon as deprecated as can done with https://github.com/xbmc/audiodecoder.openmpt (where supports more)

The deprecated mark:
![Bildschirmfoto vom 2021-04-11 17-32-00](https://user-images.githubusercontent.com/6879739/114310680-db2bb980-9aeb-11eb-9935-bfb873aac24e.png)

Performed compile and run test on Linux with C++14, C++17 and C++20.
Runtime tests was OK.